### PR TITLE
Fix Windows build TFMs

### DIFF
--- a/VoiceAssistant.Application/VoiceAssistant.Application.csproj
+++ b/VoiceAssistant.Application/VoiceAssistant.Application.csproj
@@ -4,6 +4,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />

--- a/VoiceAssistant.Tests/VoiceAssistant.Tests.csproj
+++ b/VoiceAssistant.Tests/VoiceAssistant.Tests.csproj
@@ -7,6 +7,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <TargetFramework>net9.0-windows</TargetFramework>
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 

--- a/VoiceAssistant.UI/VoiceAssistant.UI.csproj
+++ b/VoiceAssistant.UI/VoiceAssistant.UI.csproj
@@ -16,6 +16,10 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.2.7" />


### PR DESCRIPTION
## Summary
- align TFMs across projects so Windows builds reference `net9.0-windows`

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_684117d45c408329bd105519ec59209e