### PR TITLE
Fix RelayCommand thread issue and improve auth logging

### DIFF
--- a/VoiceAssistant.Infrastructure/AzureSpeechRecognizer.cs
+++ b/VoiceAssistant.Infrastructure/AzureSpeechRecognizer.cs
@@ -70,10 +70,18 @@ public class AzureSpeechRecognizer(string speechKey, string speechRegion) : IRec
         if (cancellation.Reason == CancellationReason.Error)
         {
             // Log the error details properly
-            // ErrorUri is not directly available here, usually logged internally by SDK if needed.
             Console.Error.WriteLine($"CANCELED: ErrorCode={cancellation.ErrorCode}, ErrorDetails={cancellation.ErrorDetails}");
-            message += $", ErrorCode={cancellation.ErrorCode}. Check logs for details."; // Corrected typo here
+
+            if (cancellation.ErrorCode == CancellationErrorCode.AuthenticationFailure)
+            {
+                message += ", Authentication failed. Please verify your API key and region.";
+            }
+            else
+            {
+                message += $", ErrorCode={cancellation.ErrorCode}. Check logs for details.";
+            }
         }
+
         return message;
     }
-} 
+}

--- a/VoiceAssistant.UI/Commands/RelayCommand.cs
+++ b/VoiceAssistant.UI/Commands/RelayCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Avalonia.Threading;
 
 namespace VoiceAssistant.UI.Commands;
 
@@ -88,7 +89,14 @@ public class RelayCommand : ICommand
 
     public void RaiseCanExecuteChanged()
     {
-        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+        else
+        {
+            Dispatcher.UIThread.Post(() => CanExecuteChanged?.Invoke(this, EventArgs.Empty));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- dispatch `RaiseCanExecuteChanged` to the UI thread
- give clearer messages for authentication failure in speech recognition

## Testing
- `dotnet build`
- `dotnet test --no-build -v n`

------
https://chatgpt.com/codex/tasks/task_e_68411afefd2483299831bc1df0bd4846